### PR TITLE
Update setup.py (scipy version)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
     install_requires=[
         'networkx',
         'numpy',
-        'scipy',
+        'scipy==0.12',
         'pypng',
         'ipython',
         'matplotlib',


### PR DESCRIPTION
Newer version of scipy don't support pickling stats probability distributions (https://github.com/scipy/scipy/issues/3125). This disables pickling of pymote networks. Until scipy addresses this issue, one possible solution would be to fix scipy version to 0.12.